### PR TITLE
Limit range of head rotation, ensure we cache each player separately

### DIFF
--- a/mods/minetest_game/player_api/api.lua
+++ b/mods/minetest_game/player_api/api.lua
@@ -104,18 +104,27 @@ local function yaw_to_degrees(yaw)
 	return(yaw * 180.0 / math.pi)
 end
 
-local last_look_at_dir
+local last_look = {}
 
 local function move_head(player, on_water)
+	local pname = player:get_player_name()
 	local look_at_dir = player:get_look_dir()
+	local lastlook = last_look[pname]
+	local anim = player_anim[pname] or ""
+	local anim_base = string.sub(anim, 1, 4)
 	--apply change only if the pitch changed
-	if last_look_at_dir and look_at_dir.y == last_look_at_dir.y then
+	if lastlook and look_at_dir.y == lastlook.dir.y and
+	   anim_base == lastlook.anim then
 		return
 	else
-		last_look_at_dir = look_at_dir
+		last_look[pname] = {}
+		last_look[pname].dir = look_at_dir
+		last_look[pname].anim = anim_base
 	end
 	local pitch = yaw_to_degrees(math.asin(look_at_dir.y))
-	if on_water then
+	if pitch > 70 then pitch = 70 end
+	if pitch < -50 then pitch = -50 end
+	if anim_base == "swin" or on_water then
 		pitch = pitch + 70
 	end
 	local head_rotation = {x= pitch, y= 0, z= 0} --the head movement {pitch, yaw, roll}


### PR DESCRIPTION
This is a small set of improvements to head tracking I did for Exile, and thought I'd send them upstream.
 This limits the rotation of the player's head, to look more natural, and while I was at it, I swapped out the single "last_look_dir" variable for a player name-based table, so we don't miss the cache if we switch players (which will likely happen every time if there's more than one).

 I also made it detect when animations change, because if you switched between walking and swimming without moving your head, you could end up looking in weird directions. (In Exile, I've set players to float standing up when they're not moving, and only lay flat and swim when actually moving in the water, so this would happen a lot!)